### PR TITLE
Restore legacy homepage and split QA flows across pages

### DIFF
--- a/credit.html
+++ b/credit.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Тестовое задание — Кредитная заявка</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <p class="site-header__badge">Тестовое задание для QA</p>
+      <h1 class="site-header__title">Кредитная заявка</h1>
+      <p class="site-header__subtitle">На этой странице собраны поля и сценарии, которые помогут протестировать процесс подачи кредитной заявки.</p>
+    </div>
+  </header>
+
+  <main class="page">
+    <section class="card" aria-labelledby="credit-form-title">
+      <header class="card__header">
+        <h2 id="credit-form-title">Форма заявки</h2>
+        <p class="card__hint">Заполните данные клиента. После отправки заявки появится расчёт с ежемесячным платежом и коэффициентом долговой нагрузки.</p>
+      </header>
+
+      <form id="credit-form" class="form" novalidate>
+        <div class="form__row">
+          <label class="field">
+            <span class="field__label">ФИО клиента</span>
+            <input type="text" id="client-name" name="client-name" class="field__input" placeholder="Например, Иванов Иван Иванович" required pattern="^[А-Яа-яЁё\-\s]{5,}$">
+            <span class="field__description">Допускаются только кириллица, дефис и пробелы (не менее 5 символов).</span>
+          </label>
+
+          <label class="field">
+            <span class="field__label">Номер телефона</span>
+            <input type="tel" id="client-phone" name="client-phone" class="field__input" placeholder="+7 (___) ___-__-__" required pattern="^\+7\s?\(?\d{3}\)?[\s\-]?\d{3}[\s\-]?\d{2}[\s\-]?\d{2}$">
+            <span class="field__description">Формат +7 (999) 000-00-00.</span>
+          </label>
+        </div>
+
+        <div class="form__row">
+          <label class="field">
+            <span class="field__label">Сумма кредита, ₽</span>
+            <input type="number" id="loan-amount" name="loan-amount" class="field__input" min="10000" max="10000000" step="1000" required>
+            <span class="field__description">Минимум 10 000 ₽, максимум 10 000 000 ₽.</span>
+          </label>
+
+          <label class="field">
+            <span class="field__label">Срок кредита, месяцев</span>
+            <input type="number" id="loan-term" name="loan-term" class="field__input" min="3" max="360" step="1" required>
+            <span class="field__description">От 3 до 360 месяцев.</span>
+          </label>
+        </div>
+
+        <div class="form__row">
+          <label class="field">
+            <span class="field__label">Процентная ставка, % годовых</span>
+            <input type="number" id="interest-rate" name="interest-rate" class="field__input" min="0" max="50" step="0.1" value="12" required>
+            <span class="field__description">Можно тестировать сценарии с нулевой ставкой и высокими значениями.</span>
+          </label>
+
+          <label class="field">
+            <span class="field__label">Ежемесячный доход клиента, ₽</span>
+            <input type="number" id="client-income" name="client-income" class="field__input" min="0" step="100" required>
+            <span class="field__description">Чем ниже доход, тем выше коэффициент долговой нагрузки.</span>
+          </label>
+        </div>
+
+        <label class="field">
+          <span class="field__label">Комментарий менеджера</span>
+          <textarea id="manager-comment" name="manager-comment" class="field__textarea" rows="3" placeholder="Дополнительная информация о клиенте, целях кредита или стоп-факторах"></textarea>
+        </label>
+
+        <label class="agreement">
+          <input type="checkbox" id="consent" name="consent" required>
+          <span>Подтверждаю согласие клиента на обработку персональных данных</span>
+        </label>
+
+        <button type="submit" class="button">Рассчитать заявку</button>
+      </form>
+
+      <section id="credit-result" class="result" aria-live="polite"></section>
+    </section>
+  </main>
+
+  <nav class="pagination" aria-label="Навигация по страницам">
+    <a href="index.html" class="pagination__link">1</a>
+    <a href="credit.html" class="pagination__link pagination__link--active" aria-current="page">2</a>
+    <a href="rzd.html" class="pagination__link">3</a>
+  </nav>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,12 @@
 
   <div id="toast" class="toast" role="status" aria-live="assertive"></div>
 
+  <nav class="pagination" aria-label="Навигация по страницам">
+    <a href="index.html" class="pagination__link pagination__link--active" aria-current="page">1</a>
+    <a href="credit.html" class="pagination__link">2</a>
+    <a href="rzd.html" class="pagination__link">3</a>
+  </nav>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/rzd.html
+++ b/rzd.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Тестовое задание — Касса билетов РЖД</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <p class="site-header__badge">Тестовое задание для QA</p>
+      <h1 class="site-header__title">Касса билетов РЖД</h1>
+      <p class="site-header__subtitle">Стоимость билета — 1000 ₽. Скидка зависит от возраста пассажира и времени до отправления.</p>
+    </div>
+  </header>
+
+  <main class="page">
+    <section class="card" aria-labelledby="ticket-form-title">
+      <header class="card__header">
+        <h2 id="ticket-form-title">Параметры покупки</h2>
+        <p class="card__hint">Введите возраст пассажира и сколько полных дней осталось до отправления. Алгоритм проверит ограничения и рассчитает итоговую стоимость.</p>
+      </header>
+
+      <form id="ticket-form" class="form" novalidate>
+        <div class="form__row">
+          <label class="field">
+            <span class="field__label">Возраст пассажира, лет</span>
+            <input type="number" id="passenger-age" name="passenger-age" class="field__input" min="0" max="120" step="0.01" required>
+            <span class="field__description">Можно указывать дробные значения (например, 18.5 означает 18 лет и 6 месяцев).</span>
+          </label>
+
+          <label class="field">
+            <span class="field__label">Дней до отправления</span>
+            <input type="number" id="days-before" name="days-before" class="field__input" min="0" max="365" step="1" required>
+            <span class="field__description">0 — покупка в день отправления, 1 — за один день, 2 — за два и т.д.</span>
+          </label>
+        </div>
+
+        <button type="submit" class="button">Рассчитать стоимость</button>
+      </form>
+
+      <section id="ticket-result" class="result" aria-live="polite"></section>
+
+      <section class="rules" aria-labelledby="rules-title">
+        <h2 id="rules-title">Правила расчёта скидок</h2>
+        <ul class="rules__list">
+          <li>Пассажиры младше 18 лет и ровно в 18 лет купить билет не могут.</li>
+          <li>От 18 лет 1 дня до 20 лет включительно — покупка доступна без скидки независимо от срока.</li>
+          <li>От 20 лет 1 дня до 50 лет включительно: за 1 день до отправления скидка 10%, за 2–3 дня — 35%, более чем за 3 дня — 40%.</li>
+          <li>От 50 лет 1 дня до 90 лет включительно: за 1 день до отправления скидка 15%, за 2–3 дня — 40%, более чем за 3 дня — 50%.</li>
+          <li>Возраст 100 лет и старше — покупка запрещена. Значения от 90 до 100 лет требуют уточнения и помечаются как не обслуживаются.</li>
+        </ul>
+      </section>
+    </section>
+  </main>
+
+  <nav class="pagination" aria-label="Навигация по страницам">
+    <a href="index.html" class="pagination__link">1</a>
+    <a href="credit.html" class="pagination__link">2</a>
+    <a href="rzd.html" class="pagination__link pagination__link--active" aria-current="page">3</a>
+  </nav>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,140 +1,389 @@
-const tabs = document.querySelectorAll('.tabs__tab');
-const tabContents = document.querySelectorAll('.tab-content');
-const openApplicationButton = document.getElementById('open-application');
-const applicationSection = document.getElementById('application');
-const stageElements = document.querySelectorAll('.stage');
-const nextStageButton = document.getElementById('next-stage');
-const managerInput = document.getElementById('manager');
-const toast = document.getElementById('toast');
-const profileForm = document.getElementById('profile-form');
-const nameInput = document.getElementById('name');
-const emailInput = document.getElementById('email');
-const nameError = document.getElementById('name-error');
-const emailError = document.getElementById('email-error');
+const BASE_TICKET_PRICE = 1000;
 
-const profileState = {
-  name: '',
-  email: ''
-};
+document.addEventListener('DOMContentLoaded', () => {
+  initLegacyCreditApp();
+  initCreditForm();
+  initTicketForm();
+});
 
-let currentStageIndex = 0;
-let toastTimeout;
+function initLegacyCreditApp() {
+  const tabs = document.querySelectorAll('.tabs__tab');
+  const tabContents = document.querySelectorAll('.tab-content');
+  const openApplicationButton = document.getElementById('open-application');
+  const applicationSection = document.getElementById('application');
+  const stageElements = document.querySelectorAll('.stage');
+  const nextStageButton = document.getElementById('next-stage');
+  const managerInput = document.getElementById('manager');
+  const toast = document.getElementById('toast');
+  const profileForm = document.getElementById('profile-form');
+  const nameInput = document.getElementById('name');
+  const emailInput = document.getElementById('email');
+  const nameError = document.getElementById('name-error');
+  const emailError = document.getElementById('email-error');
 
-function switchTab(targetId) {
-  tabContents.forEach((content) => {
-    const isActive = content.id === targetId;
-    content.classList.toggle('tab-content--active', isActive);
-  });
+  if (
+    !tabs.length ||
+    !tabContents.length ||
+    !openApplicationButton ||
+    !applicationSection ||
+    !stageElements.length ||
+    !nextStageButton ||
+    !managerInput ||
+    !toast ||
+    !profileForm ||
+    !nameInput ||
+    !emailInput ||
+    !nameError ||
+    !emailError
+  ) {
+    return;
+  }
+
+  const profileState = { name: '', email: '' };
+  let currentStageIndex = 0;
+  let toastTimeout;
+
+  function switchTab(targetId) {
+    tabContents.forEach((content) => {
+      const isActive = content.id === targetId;
+      content.classList.toggle('tab-content--active', isActive);
+      content.setAttribute('aria-hidden', String(!isActive));
+    });
+
+    tabs.forEach((tab) => {
+      const isActive = tab.dataset.target === targetId;
+      tab.classList.toggle('tabs__tab--active', isActive);
+      tab.setAttribute('aria-selected', String(isActive));
+    });
+  }
+
+  const currentActiveTab = Array.from(tabs).find((tab) => tab.classList.contains('tabs__tab--active')) || tabs[0];
+  if (currentActiveTab) {
+    switchTab(currentActiveTab.dataset.target);
+  }
 
   tabs.forEach((tab) => {
-    const isActive = tab.dataset.target === targetId;
-    tab.classList.toggle('tabs__tab--active', isActive);
-    tab.setAttribute('aria-selected', String(isActive));
+    tab.addEventListener('click', () => {
+      switchTab(tab.dataset.target);
+    });
   });
-}
 
-tabs.forEach((tab) => {
-  tab.addEventListener('click', () => {
-    switchTab(tab.dataset.target);
+  openApplicationButton.addEventListener('click', () => {
+    applicationSection.classList.remove('application--hidden');
+    applicationSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
   });
-});
 
-openApplicationButton.addEventListener('click', () => {
-  applicationSection.classList.remove('application--hidden');
-  applicationSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-});
+  function validateName(value) {
+    const trimmed = value.trim();
 
-function validateName(value) {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    nameError.textContent = 'Укажите имя.';
-    return false;
+    if (!trimmed) {
+      nameError.textContent = 'Укажите имя.';
+      return false;
+    }
+
+    const namePattern = /^[А-Яа-яЁё\s]{2,}$/;
+    if (!namePattern.test(trimmed)) {
+      nameError.textContent = 'Имя должно содержать минимум 2 буквы кириллицы.';
+      return false;
+    }
+
+    nameError.textContent = '';
+    return true;
   }
 
-  const namePattern = /^[А-Яа-яЁё\s]{2,}$/;
-  if (!namePattern.test(trimmed)) {
-    nameError.textContent = 'Имя должно содержать минимум 2 буквы кириллицы.';
-    return false;
-  }
+  function validateEmail(value) {
+    const trimmed = value.trim();
 
-  nameError.textContent = '';
-  return true;
-}
+    if (!trimmed) {
+      emailError.textContent = '';
+      return true;
+    }
 
-function validateEmail(value) {
-  const trimmed = value.trim();
-  if (!trimmed) {
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(trimmed)) {
+      emailError.textContent = 'Укажите корректный email в формате user@example.com.';
+      return false;
+    }
+
     emailError.textContent = '';
     return true;
   }
 
-  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailPattern.test(trimmed)) {
-    emailError.textContent = 'Укажите корректный email в формате user@example.com.';
-    return false;
+  profileForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const isNameValid = validateName(nameInput.value);
+    const isEmailValid = validateEmail(emailInput.value);
+
+    if (!isNameValid || !isEmailValid) {
+      return;
+    }
+
+    profileState.name = nameInput.value.trim();
+    profileState.email = emailInput.value.trim();
+
+    showToast('Профиль сохранён.');
+  });
+
+  managerInput.addEventListener('click', () => {
+    if (profileState.name) {
+      managerInput.value = profileState.name;
+    } else {
+      showToast('Сначала заполните и сохраните имя в профиле.');
+    }
+  });
+
+  function updateStages() {
+    stageElements.forEach((stageElement, index) => {
+      stageElement.classList.toggle('stage--active', index === currentStageIndex);
+      stageElement.classList.toggle('stage--completed', index < currentStageIndex);
+    });
   }
 
-  emailError.textContent = '';
-  return true;
+  function showToast(message) {
+    toast.textContent = message;
+    toast.classList.add('toast--visible');
+    clearTimeout(toastTimeout);
+    toastTimeout = setTimeout(() => {
+      toast.classList.remove('toast--visible');
+    }, 3500);
+  }
+
+  nextStageButton.addEventListener('click', () => {
+    if (currentStageIndex >= stageElements.length - 1) {
+      showToast('Все этапы уже пройдены.');
+      return;
+    }
+
+    if (!managerInput.value.trim()) {
+      showToast('Стоп-условие. Поле "Менеджер" должно быть заполнено');
+      return;
+    }
+
+    currentStageIndex += 1;
+    updateStages();
+
+    if (profileState.email) {
+      showToast('Уведомление менеджера о смене этапа заявки отправлено');
+    } else {
+      showToast('Уведомление менеджера о смене этапа заявки не отправлено');
+    }
+  });
+
+  updateStages();
 }
 
-profileForm.addEventListener('submit', (event) => {
-  event.preventDefault();
-  const isNameValid = validateName(nameInput.value);
-  const isEmailValid = validateEmail(emailInput.value);
+function initCreditForm() {
+  const creditForm = document.getElementById('credit-form');
+  const resultContainer = document.getElementById('credit-result');
 
-  if (!isNameValid || !isEmailValid) {
+  if (!creditForm || !resultContainer) {
     return;
   }
 
-  profileState.name = nameInput.value.trim();
-  profileState.email = emailInput.value.trim();
-  showToast('Профиль сохранён.');
-});
+  creditForm.addEventListener('submit', (event) => {
+    event.preventDefault();
 
-managerInput.addEventListener('click', () => {
-  if (profileState.name) {
-    managerInput.value = profileState.name;
-  } else {
-    showToast('Сначала заполните и сохраните имя в профиле.');
-  }
-});
+    if (!creditForm.checkValidity()) {
+      creditForm.reportValidity();
+      return;
+    }
 
-function updateStages() {
-  stageElements.forEach((stageElement, index) => {
-    stageElement.classList.toggle('stage--active', index === currentStageIndex);
-    stageElement.classList.toggle('stage--completed', index < currentStageIndex);
+    const amount = parseFloat(creditForm.elements['loan-amount'].value);
+    const term = parseInt(creditForm.elements['loan-term'].value, 10);
+    const rate = parseFloat(creditForm.elements['interest-rate'].value);
+    const income = parseFloat(creditForm.elements['client-income'].value);
+    const name = creditForm.elements['client-name'].value.trim();
+    const phone = creditForm.elements['client-phone'].value.trim();
+    const comment = creditForm.elements['manager-comment'].value.trim();
+
+    const payment = calculateMonthlyPayment(amount, rate, term);
+    const dti = income > 0 ? payment / income : null;
+
+    const formatter = new Intl.NumberFormat('ru-RU', {
+      style: 'currency',
+      currency: 'RUB',
+      maximumFractionDigits: 0
+    });
+
+    const rows = [
+      { label: 'Клиент', value: name },
+      { label: 'Телефон', value: phone },
+      { label: 'Сумма кредита', value: formatter.format(amount) },
+      { label: 'Срок кредита', value: `${term} мес.` },
+      { label: 'Процентная ставка', value: `${rate.toFixed(2)}% годовых` },
+      { label: 'Ежемесячный платёж', value: formatter.format(payment) },
+      {
+        label: 'Коэффициент долговой нагрузки',
+        value: dti === null ? 'Доход не указан' : `${(dti * 100).toFixed(1)}% от дохода`
+      },
+      {
+        label: 'Комментарий',
+        value: comment ? comment : '—'
+      }
+    ];
+
+    resultContainer.innerHTML = `
+      <h3>Результат расчёта</h3>
+      <dl class="result__list">
+        ${rows.map((row) => `
+          <div class="result__item">
+            <dt>${row.label}</dt>
+            <dd>${row.value}</dd>
+          </div>
+        `).join('')}
+      </dl>
+      <p class="result__note">Клиент должен подтвердить корректность данных перед отправкой в скоринг.</p>
+    `;
   });
 }
 
-function showToast(message) {
-  toast.textContent = message;
-  toast.classList.add('toast--visible');
-  clearTimeout(toastTimeout);
-  toastTimeout = setTimeout(() => {
-    toast.classList.remove('toast--visible');
-  }, 3500);
+function calculateMonthlyPayment(amount, rate, term) {
+  const monthlyRate = rate <= 0 ? 0 : rate / 100 / 12;
+
+  if (monthlyRate === 0) {
+    return amount / term;
+  }
+
+  const factor = Math.pow(1 + monthlyRate, term);
+  return amount * monthlyRate * factor / (factor - 1);
 }
 
-nextStageButton.addEventListener('click', () => {
-  if (currentStageIndex >= stageElements.length - 1) {
-    showToast('Все этапы уже пройдены.');
+function initTicketForm() {
+  const ticketForm = document.getElementById('ticket-form');
+  const resultContainer = document.getElementById('ticket-result');
+
+  if (!ticketForm || !resultContainer) {
     return;
   }
 
-  if (!managerInput.value.trim()) {
-    showToast('Стоп-условие. Поле "Менеджер" должно быть заполнено');
-    return;
+  ticketForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    if (!ticketForm.checkValidity()) {
+      ticketForm.reportValidity();
+      return;
+    }
+
+    const age = parseFloat(ticketForm.elements['passenger-age'].value);
+    const daysBefore = parseInt(ticketForm.elements['days-before'].value, 10);
+
+    const ticketDecision = determineTicketDecision(age, daysBefore);
+
+    if (!ticketDecision.allowed) {
+      resultContainer.innerHTML = `
+        <div class="result__alert" role="alert">
+          <h3>Покупка недоступна</h3>
+          <p>${ticketDecision.reason}</p>
+        </div>
+      `;
+      return;
+    }
+
+    const discountAmount = BASE_TICKET_PRICE * ticketDecision.discount;
+    const finalPrice = BASE_TICKET_PRICE - discountAmount;
+    const formatter = new Intl.NumberFormat('ru-RU', {
+      style: 'currency',
+      currency: 'RUB',
+      maximumFractionDigits: 2
+    });
+
+    const daysLabel = daysBefore === 1 ? '1 день' : `${daysBefore} дн.`;
+
+    resultContainer.innerHTML = `
+      <h3>Расчёт стоимости</h3>
+      <dl class="result__list">
+        <div class="result__item">
+          <dt>Базовая стоимость</dt>
+          <dd>${formatter.format(BASE_TICKET_PRICE)}</dd>
+        </div>
+        <div class="result__item">
+          <dt>Скидка</dt>
+          <dd>${(ticketDecision.discount * 100).toFixed(0)}%</dd>
+        </div>
+        <div class="result__item">
+          <dt>Размер скидки</dt>
+          <dd>${formatter.format(discountAmount)}</dd>
+        </div>
+        <div class="result__item">
+          <dt>Итого к оплате</dt>
+          <dd>${formatter.format(finalPrice)}</dd>
+        </div>
+      </dl>
+      <p class="result__note">Скидка выбрана согласно правилам для возраста ${age} лет и покупки за ${daysLabel} до отправления.</p>
+    `;
+  });
+}
+
+function determineTicketDecision(age, daysBefore) {
+  if (Number.isNaN(age) || Number.isNaN(daysBefore)) {
+    return {
+      allowed: false,
+      reason: 'Укажите корректный возраст и количество дней до отправления.'
+    };
   }
 
-  currentStageIndex += 1;
-  updateStages();
+  if (daysBefore < 0) {
+    return {
+      allowed: false,
+      reason: 'Количество дней до отправления не может быть отрицательным.'
+    };
+  }
 
-  if (profileState.email) {
-    showToast('Уведомление менеджера о смене этапа заявки отправлено');
+  if (age <= 18) {
+    return {
+      allowed: false,
+      reason: 'Пассажиры младше 18 лет или ровно в 18 лет купить билет не могут.'
+    };
+  }
+
+  if (age >= 100) {
+    return {
+      allowed: false,
+      reason: 'Возраст 100 лет и старше не обслуживается кассой.'
+    };
+  }
+
+  if (age > 90 && age < 100) {
+    return {
+      allowed: false,
+      reason: 'Для пассажиров старше 90 лет требуется ручная проверка — продажа онлайн недоступна.'
+    };
+  }
+
+  let discount = 0;
+
+  if (age > 18 && age <= 20) {
+    discount = 0;
+  } else if (age > 20 && age <= 50) {
+    discount = selectDiscount(daysBefore, 0.10, 0.35, 0.40);
+  } else if (age > 50 && age <= 90) {
+    discount = selectDiscount(daysBefore, 0.15, 0.40, 0.50);
   } else {
-    showToast('Уведомление менеджера о смене этапа заявки не отправлено');
+    return {
+      allowed: false,
+      reason: 'Возраст пассажира вне заданных диапазонов. Обратитесь в поддержку.'
+    };
   }
-});
 
-updateStages();
+  return {
+    allowed: true,
+    discount
+  };
+}
+
+function selectDiscount(daysBefore, oneDayDiscount, threeDayDiscount, longDiscount) {
+  if (daysBefore === 1) {
+    return oneDayDiscount;
+  }
+
+  if (daysBefore >= 2 && daysBefore <= 3) {
+    return threeDayDiscount;
+  }
+
+  if (daysBefore > 3) {
+    return longDiscount;
+  }
+
+  return 0;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,28 +1,43 @@
 :root {
+  --bg-color: #f6f7fb;
+  --card-bg: #ffffff;
+  --accent: #0b74d1;
+  --accent-dark: #055494;
+  --text-color: #1f2933;
+  --muted: #6b7280;
+  --border: #d1d5db;
+  --radius: 16px;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
   --primary-color: #0b74d1;
   --primary-dark: #055494;
   --background: #f5f7fb;
-  --card-bg: #ffffff;
-  --text-color: #1f2933;
   --muted-color: #6c7a89;
   --error-color: #c0392b;
   --success-color: #2ecc71;
-  --border-radius: 12px;
+  --border-radius: 16px;
   --transition: 0.3s ease;
-  font-family: 'Segoe UI', Tahoma, sans-serif;
+  font-family: 'Inter', 'Segoe UI', Tahoma, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--background);
+  background: linear-gradient(180deg, rgba(11, 116, 209, 0.08), transparent 45%), var(--bg-color);
   color: var(--text-color);
+  display: flex;
+  flex-direction: column;
 }
 
 .app {
   max-width: 960px;
   margin: 0 auto;
   padding: 32px 16px 48px;
+  flex: 1 0 auto;
+  width: 100%;
 }
 
 .app__header {
@@ -58,9 +73,11 @@ body {
 }
 
 .tabs__tab--active,
-.tabs__tab:hover {
+.tabs__tab:hover,
+.tabs__tab:focus {
   background: var(--primary-color);
   color: #fff;
+  outline: none;
 }
 
 .tab-content {
@@ -91,6 +108,7 @@ body {
 .primary-button:hover,
 .primary-button:focus {
   background: var(--primary-dark);
+  outline: none;
 }
 
 .application {
@@ -154,6 +172,7 @@ body {
 .stage-control:focus {
   background: var(--primary-dark);
   transform: translateX(2px);
+  outline: none;
 }
 
 .application__body {
@@ -162,34 +181,17 @@ body {
   flex-wrap: wrap;
 }
 
-.field {
+.application .field {
   display: flex;
   flex-direction: column;
   gap: 8px;
   flex: 1 1 280px;
 }
 
-.field__label {
-  font-weight: 600;
-}
-
-.field__input {
-  padding: 12px 14px;
-  border-radius: 10px;
-  border: 1px solid rgba(31, 41, 51, 0.2);
-  font-size: 16px;
-  transition: border-color var(--transition), box-shadow var(--transition);
-}
-
-.field__input:focus {
-  border-color: var(--primary-color);
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(11, 116, 209, 0.15);
-}
-
-.field__input[readonly] {
-  cursor: pointer;
-  background: rgba(11, 116, 209, 0.05);
+.field__error {
+  min-height: 18px;
+  color: var(--error-color);
+  font-size: 13px;
 }
 
 .profile__hint {
@@ -198,10 +200,9 @@ body {
   font-size: 14px;
 }
 
-.field__error {
-  min-height: 18px;
-  color: var(--error-color);
-  font-size: 13px;
+.field__input[readonly] {
+  cursor: pointer;
+  background: rgba(11, 116, 209, 0.05);
 }
 
 .toast {
@@ -225,12 +226,291 @@ body {
   transform: translateY(0);
 }
 
+.site-header {
+  padding: 40px 16px 24px;
+}
+
+.site-header__inner {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.site-header__badge {
+  display: inline-block;
+  padding: 6px 14px;
+  background: rgba(11, 116, 209, 0.12);
+  color: var(--accent-dark);
+  border-radius: 999px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.site-header__title {
+  margin: 0 0 12px;
+  font-size: clamp(28px, 3vw, 40px);
+}
+
+.site-header__subtitle {
+  margin: 0;
+  max-width: 720px;
+  font-size: 18px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.page {
+  flex: 1;
+  padding: 0 16px 40px;
+  display: flex;
+  justify-content: center;
+}
+
+.card {
+  max-width: 960px;
+  width: 100%;
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 32px;
+  display: grid;
+  gap: 32px;
+}
+
+.card__header h2 {
+  margin: 0 0 12px;
+  font-size: 24px;
+}
+
+.card__hint {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.form {
+  display: grid;
+  gap: 24px;
+}
+
+.form__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field__label {
+  font-weight: 600;
+}
+
+.field__input,
+.field__textarea {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font-size: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field__textarea {
+  resize: vertical;
+  min-height: 110px;
+}
+
+.field__input:focus,
+.field__textarea:focus {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(11, 116, 209, 0.15);
+}
+
+.field__description {
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.agreement {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 15px;
+}
+
+.agreement input {
+  width: 18px;
+  height: 18px;
+}
+
+.button {
+  justify-self: start;
+  background: linear-gradient(135deg, var(--accent), #5aa9e6);
+  border: none;
+  color: #fff;
+  font-weight: 600;
+  font-size: 16px;
+  padding: 14px 28px;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 18px 30px rgba(11, 116, 209, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 38px rgba(11, 116, 209, 0.35);
+  outline: none;
+}
+
+.result {
+  background: rgba(11, 116, 209, 0.05);
+  border-radius: 14px;
+  padding: 24px;
+  display: grid;
+  gap: 18px;
+  border: 1px dashed rgba(11, 116, 209, 0.4);
+}
+
+.result h3 {
+  margin: 0;
+}
+
+.result__list {
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.result__item {
+  display: grid;
+  gap: 4px;
+}
+
+.result__item dt {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.result__item dd {
+  margin: 0;
+  font-size: 18px;
+}
+
+.result__note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.result__alert {
+  background: #fee2e2;
+  border: 1px solid #f87171;
+  border-radius: 14px;
+  padding: 20px;
+  display: grid;
+  gap: 8px;
+}
+
+.result__alert h3 {
+  margin: 0;
+  color: #b91c1c;
+}
+
+.rules {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding-top: 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.rules__list {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px 16px 40px;
+}
+
+.pagination__link {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  color: var(--text-color);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.pagination__link:hover,
+.pagination__link:focus {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  outline: none;
+}
+
+.pagination__link--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(11, 116, 209, 0.35);
+}
+
 @media (max-width: 768px) {
+  .app {
+    padding: 24px 12px 40px;
+  }
+
   .stages {
     grid-template-columns: repeat(2, minmax(160px, 1fr));
   }
 
   .stage-control {
     justify-self: stretch;
+  }
+
+  .card {
+    padding: 24px;
+  }
+
+  .button {
+    width: 100%;
+    justify-self: stretch;
+  }
+
+  .pagination {
+    padding-bottom: 32px;
+  }
+}
+
+@media (max-width: 480px) {
+  .site-header {
+    padding-top: 24px;
+  }
+
+  .card {
+    padding: 20px;
+    border-radius: 14px;
+  }
+
+  .result {
+    padding: 20px;
   }
 }


### PR DESCRIPTION
## Summary
- restore the original credit application home and add pagination for switching between scenarios
- move the enhanced credit calculator to a new credit.html page and keep the RZD ticket task as the third page
- update shared scripts and styles so legacy interactions and the new calculators work together

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2fc6a39c832087ed6a8173fb61af