### PR TITLE
Add fourth interactive lifestyle scenarios page

### DIFF
--- a/credit.html
+++ b/credit.html
@@ -86,6 +86,7 @@
     <a href="index.html" class="pagination__link">1</a>
     <a href="credit.html" class="pagination__link pagination__link--active" aria-current="page">2</a>
     <a href="rzd.html" class="pagination__link">3</a>
+    <a href="lifestyle.html" class="pagination__link">4</a>
   </nav>
 
   <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
     <a href="index.html" class="pagination__link pagination__link--active" aria-current="page">1</a>
     <a href="credit.html" class="pagination__link">2</a>
     <a href="rzd.html" class="pagination__link">3</a>
+    <a href="lifestyle.html" class="pagination__link">4</a>
   </nav>
 
   <script src="script.js"></script>

--- a/lifestyle.html
+++ b/lifestyle.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Тестовое задание — Интерактивные сценарии</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <p class="site-header__badge">Тестовое задание для QA</p>
+      <h1 class="site-header__title">Интерактивные сценарии</h1>
+      <p class="site-header__subtitle">Четыре независимых блока для проверки обязательных полей, динамических расчётов и уведомлений.</p>
+    </div>
+  </header>
+
+  <main class="page">
+    <div class="quad-grid">
+      <section class="quad" aria-labelledby="comment-title">
+        <div class="quad__header">
+          <h2 id="comment-title" class="quad__title">Комментарий</h2>
+          <p class="quad__note">Проверьте обязательное поле с валидацией длины и символов.</p>
+        </div>
+        <form id="comment-form" class="quad-form" novalidate>
+          <label class="field">
+            <span class="field__label">Комментарий</span>
+            <textarea id="comment-text" name="comment" class="field__textarea" rows="6" required maxlength="500" placeholder="Напишите своё впечатление"></textarea>
+          </label>
+          <span class="field__error" id="comment-error"></span>
+          <button type="submit" class="button">Сохранить</button>
+        </form>
+      </section>
+
+      <section class="quad" id="happiness-section" aria-labelledby="happiness-title">
+        <div class="quad__header">
+          <h2 id="happiness-title" class="quad__title">Индекс счастья</h2>
+          <p class="quad__note">Комбинируйте факторы и наблюдайте за пересчётом индекса.</p>
+        </div>
+        <div class="checkbox-group">
+          <label class="checkbox">
+            <input type="checkbox" name="happiness" value="morning" data-value="12">
+            <span>Утренние пробежки и зарядка</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="happiness" value="work" data-value="18">
+            <span>Любимая работа и признание</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="happiness" value="family" data-value="20">
+            <span>Тёплые семейные вечера</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="happiness" value="travel" data-value="15">
+            <span>Путешествия дважды в год</span>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="happiness" value="gratitude" data-value="10">
+            <span>Ежедневная благодарность</span>
+          </label>
+        </div>
+        <div class="happiness-output" aria-live="polite">
+          <span class="happiness-output__label">Индекс счастья</span>
+          <input type="text" id="happiness-index" class="happiness-output__value" value="0" readonly>
+        </div>
+      </section>
+
+      <section class="quad" aria-labelledby="card-title">
+        <div class="quad__header">
+          <h2 id="card-title" class="quad__title">Выбор банковской карты</h2>
+          <p class="quad__note">Изучите условия предложений и сохраните заявку.</p>
+        </div>
+        <form id="card-form" class="quad-form" novalidate>
+          <label class="field">
+            <span class="field__label">Тип карты</span>
+            <select id="card-type" name="card-type" class="field__select" required>
+              <option value="">Выберите вариант</option>
+              <option value="debit">Дебетовая</option>
+              <option value="business">Бизнес</option>
+              <option value="credit">Кредитная</option>
+              <option value="gold">Золотая</option>
+              <option value="platinum">Платиновая</option>
+              <option value="travel">Путешествия</option>
+              <option value="youth">Молодёжная</option>
+              <option value="premium">Премиальная</option>
+              <option value="digital">Цифровая</option>
+              <option value="cobrand">Кобрендинговая</option>
+            </select>
+          </label>
+
+          <div id="card-details" class="card-details" aria-live="polite">
+            <p class="placeholder">Выберите карту, чтобы увидеть условия.</p>
+          </div>
+
+          <fieldset class="radio-group">
+            <legend class="radio-group__legend">Получатель карты</legend>
+            <label class="radio">
+              <input type="radio" name="card-gender" value="male">
+              <span>Мужчина</span>
+            </label>
+            <label class="radio">
+              <input type="radio" name="card-gender" value="female">
+              <span>Женщина</span>
+            </label>
+          </fieldset>
+
+          <span class="field__error" id="card-error"></span>
+
+          <button type="submit" class="button">Оформить</button>
+        </form>
+      </section>
+
+      <section class="quad" aria-labelledby="phone-title">
+        <div class="quad__header">
+          <h2 id="phone-title" class="quad__title">SIM и контактный номер</h2>
+          <p class="quad__note">Проверьте маску телефона и выбор оператора.</p>
+        </div>
+        <form id="phone-form" class="quad-form" novalidate>
+          <label class="field">
+            <span class="field__label">Телефон</span>
+            <input type="tel" id="phone-number" name="phone-number" class="field__input" placeholder="+7 999 999 99 99" required>
+          </label>
+
+          <label class="field">
+            <span class="field__label">SIM</span>
+            <select id="sim-provider" name="sim-provider" class="field__select" required>
+              <option value="">Выберите оператора</option>
+              <option value="beeline">Билайн</option>
+              <option value="tele2">Теле2</option>
+              <option value="mts">МТС</option>
+            </select>
+          </label>
+
+          <span class="field__error" id="phone-error"></span>
+
+          <button type="submit" class="button">Сохранить</button>
+        </form>
+      </section>
+    </div>
+  </main>
+
+  <div id="toast" class="toast" role="status" aria-live="assertive"></div>
+
+  <nav class="pagination" aria-label="Навигация по страницам">
+    <a href="index.html" class="pagination__link">1</a>
+    <a href="credit.html" class="pagination__link">2</a>
+    <a href="rzd.html" class="pagination__link">3</a>
+    <a href="lifestyle.html" class="pagination__link pagination__link--active" aria-current="page">4</a>
+  </nav>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/rzd.html
+++ b/rzd.html
@@ -59,6 +59,7 @@
     <a href="index.html" class="pagination__link">1</a>
     <a href="credit.html" class="pagination__link">2</a>
     <a href="rzd.html" class="pagination__link pagination__link--active" aria-current="page">3</a>
+    <a href="lifestyle.html" class="pagination__link">4</a>
   </nav>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initLegacyCreditApp();
   initCreditForm();
   initTicketForm();
+  initLifestylePage();
 });
 
 function initLegacyCreditApp() {
@@ -386,4 +387,311 @@ function selectDiscount(daysBefore, oneDayDiscount, threeDayDiscount, longDiscou
   }
 
   return 0;
+}
+
+const showGlobalToast = (() => {
+  let timeoutId;
+
+  return function showGlobalToast(message) {
+    const toast = document.getElementById('toast');
+
+    if (!toast) {
+      return;
+    }
+
+    toast.textContent = message;
+    toast.classList.add('toast--visible');
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      toast.classList.remove('toast--visible');
+    }, 3500);
+  };
+})();
+
+function initLifestylePage() {
+  const commentForm = document.getElementById('comment-form');
+  const commentInput = document.getElementById('comment-text');
+  const commentError = document.getElementById('comment-error');
+  const happinessSection = document.getElementById('happiness-section');
+  const happinessCheckboxes = happinessSection ? happinessSection.querySelectorAll('input[type="checkbox"]') : null;
+  const happinessIndexField = document.getElementById('happiness-index');
+  const cardForm = document.getElementById('card-form');
+  const cardSelect = document.getElementById('card-type');
+  const cardDetailsContainer = document.getElementById('card-details');
+  const cardError = document.getElementById('card-error');
+  const phoneForm = document.getElementById('phone-form');
+  const phoneInput = document.getElementById('phone-number');
+  const phoneError = document.getElementById('phone-error');
+  const simSelect = document.getElementById('sim-provider');
+
+  if (
+    !commentForm ||
+    !commentInput ||
+    !commentError ||
+    !happinessCheckboxes ||
+    !happinessIndexField ||
+    !cardForm ||
+    !cardSelect ||
+    !cardDetailsContainer ||
+    !cardError ||
+    !phoneForm ||
+    !phoneInput ||
+    !phoneError ||
+    !simSelect
+  ) {
+    return;
+  }
+
+  const commentPattern = /^[A-Za-zА-Яа-яЁё\s.,!?"'()\-]+$/;
+
+  commentForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const value = commentInput.value.trim();
+
+    if (!value) {
+      commentError.textContent = 'Комментарий обязателен.';
+      commentInput.focus();
+      return;
+    }
+
+    if (value.length > 500) {
+      commentError.textContent = 'Слишком длинный комментарий.';
+      commentInput.focus();
+      return;
+    }
+
+    if (!commentPattern.test(value)) {
+      commentError.textContent = 'Используйте допустимые символы.';
+      commentInput.focus();
+      return;
+    }
+
+    commentError.textContent = '';
+    showGlobalToast('Успех операции');
+  });
+
+  commentInput.addEventListener('input', () => {
+    if (commentError.textContent) {
+      commentError.textContent = '';
+    }
+  });
+
+  if (happinessCheckboxes.length) {
+    const updateHappinessIndex = () => {
+      let index = 0;
+
+      happinessCheckboxes.forEach((checkbox) => {
+        if (checkbox.checked) {
+          index += Number(checkbox.dataset.value || 0);
+        }
+      });
+
+      happinessIndexField.value = index.toString();
+    };
+
+    happinessCheckboxes.forEach((checkbox) => {
+      checkbox.addEventListener('change', updateHappinessIndex);
+    });
+
+    updateHappinessIndex();
+  }
+
+  const cardDetailsMap = {
+    debit: [
+      { label: 'Тариф', value: '«Свободный баланс»' },
+      { label: 'Стоимость обслуживания', value: '0 ₽ при покупках от 5 000 ₽' },
+      { label: 'Кешбек за покупки', value: '5% в супермаркетах' }
+    ],
+    business: [
+      { label: 'Тариф', value: '«Бизнес-старт»' },
+      { label: 'Стоимость обслуживания', value: '2 490 ₽ в месяц' },
+      { label: 'Акция', value: 'Возврат 20% на рекламу' }
+    ],
+    credit: [
+      { label: 'Льготный период', value: '120 дней без процентов' },
+      { label: 'Стоимость обслуживания', value: '1 990 ₽ в год' },
+      { label: 'Кешбек за покупки', value: '7% в путешествиях' }
+    ],
+    gold: [
+      { label: 'Тариф', value: '«Золотая карта»' },
+      { label: 'Процент на остаток', value: '4.5% на счёте' },
+      { label: 'Кешбек за покупки', value: '10% в категориях месяца' }
+    ],
+    platinum: [
+      { label: 'Тариф', value: '«Platinum Select»' },
+      { label: 'Стоимость обслуживания', value: '4 990 ₽ в год' },
+      { label: 'Акция', value: 'Доступ в бизнес-залы 6 раз в год' }
+    ],
+    travel: [
+      { label: 'Тариф', value: '«Путешествуй»' },
+      { label: 'Льготный период', value: '90 дней без процентов' },
+      { label: 'Бонусы', value: 'Мили за каждую покупку' }
+    ],
+    youth: [
+      { label: 'Тариф', value: '«Юниор»' },
+      { label: 'Стоимость обслуживания', value: '0 ₽ до 23 лет' },
+      { label: 'Процент на остаток', value: '6% при активных покупках' }
+    ],
+    premium: [
+      { label: 'Тариф', value: '«Premium Club»' },
+      { label: 'Стоимость обслуживания', value: '9 900 ₽ в год' },
+      { label: 'Акция', value: 'Персональный менеджер 24/7' }
+    ],
+    digital: [
+      { label: 'Тариф', value: '«Онлайн-поток»' },
+      { label: 'Стоимость обслуживания', value: '0 ₽ при подписке на сервисы' },
+      { label: 'Кешбек за покупки', value: '5% на цифровые товары' }
+    ],
+    cobrand: [
+      { label: 'Партнёр', value: 'Авиакомпания «Северное небо»' },
+      { label: 'Льготный период', value: '60 дней без процентов' },
+      { label: 'Кешбек за покупки', value: 'Бонусные мили х2 у партнёра' }
+    ]
+  };
+
+  const renderCardDetails = (cardType) => {
+    const details = cardDetailsMap[cardType];
+
+    if (!details) {
+      cardDetailsContainer.innerHTML = '<p class="placeholder">Выберите карту, чтобы увидеть условия.</p>';
+      return;
+    }
+
+    const items = details
+      .map((detail) => `
+        <div class="details-list__item">
+          <dt>${detail.label}</dt>
+          <dd>${detail.value}</dd>
+        </div>
+      `)
+      .join('');
+
+    cardDetailsContainer.innerHTML = `
+      <dl class="details-list">
+        ${items}
+      </dl>
+    `;
+  };
+
+  renderCardDetails(cardSelect.value);
+
+  cardSelect.addEventListener('change', () => {
+    if (cardError.textContent) {
+      cardError.textContent = '';
+    }
+    renderCardDetails(cardSelect.value);
+  });
+
+  cardForm.addEventListener('change', (event) => {
+    if (event.target.name === 'card-gender' && cardError.textContent) {
+      cardError.textContent = '';
+    }
+  });
+
+  cardForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const selectedCard = cardSelect.value;
+    const selectedGender = cardForm.querySelector('input[name="card-gender"]:checked');
+
+    if (!selectedCard) {
+      cardError.textContent = 'Выберите тип карты.';
+      cardSelect.focus();
+      return;
+    }
+
+    if (!selectedGender) {
+      cardError.textContent = 'Укажите получателя карты.';
+      return;
+    }
+
+    cardError.textContent = '';
+
+    if (selectedGender.value === 'male') {
+      showGlobalToast('Карточка оформлена, бонус за карту 100 рублей');
+    } else {
+      showGlobalToast('Карточка оформлена, бонус за карту 69 рублей');
+    }
+  });
+
+  const phonePattern = /^\+7\s\d{3}\s\d{3}\s\d{2}\s\d{2}$/;
+
+  const formatPhone = (value) => {
+    const digits = value.replace(/\D/g, '');
+
+    if (!digits) {
+      return '';
+    }
+
+    let normalized = digits;
+
+    if (normalized.startsWith('8')) {
+      normalized = `7${normalized.slice(1)}`;
+    }
+
+    if (!normalized.startsWith('7')) {
+      normalized = `7${normalized}`;
+    }
+
+    normalized = normalized.slice(0, 11);
+
+    const rest = normalized.slice(1);
+    let result = '+7';
+
+    if (rest.length > 0) {
+      result += ` ${rest.slice(0, 3)}`;
+    }
+
+    if (rest.length > 3) {
+      result += ` ${rest.slice(3, 6)}`;
+    }
+
+    if (rest.length > 6) {
+      result += ` ${rest.slice(6, 8)}`;
+    }
+
+    if (rest.length > 8) {
+      result += ` ${rest.slice(8, 10)}`;
+    }
+
+    return result;
+  };
+
+  phoneInput.addEventListener('input', (event) => {
+    const formatted = formatPhone(event.target.value);
+    event.target.value = formatted;
+
+    if (phoneError.textContent) {
+      phoneError.textContent = '';
+    }
+  });
+
+  simSelect.addEventListener('change', () => {
+    if (phoneError.textContent) {
+      phoneError.textContent = '';
+    }
+  });
+
+  phoneForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const value = phoneInput.value.trim();
+    const provider = simSelect.value;
+
+    if (!phonePattern.test(value)) {
+      phoneError.textContent = 'Укажите телефон в формате +7 999 999 99 99.';
+      phoneInput.focus();
+      return;
+    }
+
+    if (!provider) {
+      phoneError.textContent = 'Выберите оператора.';
+      simSelect.focus();
+      return;
+    }
+
+    phoneError.textContent = '';
+    showGlobalToast('Успех операции');
+  });
 }

--- a/styles.css
+++ b/styles.css
@@ -308,7 +308,8 @@ body {
 }
 
 .field__input,
-.field__textarea {
+.field__textarea,
+.field__select {
   width: 100%;
   padding: 14px 16px;
   border-radius: 12px;
@@ -323,7 +324,8 @@ body {
 }
 
 .field__input:focus,
-.field__textarea:focus {
+.field__textarea:focus,
+.field__select:focus {
   border-color: var(--accent);
   outline: none;
   box-shadow: 0 0 0 4px rgba(11, 116, 209, 0.15);
@@ -473,6 +475,159 @@ body {
   box-shadow: 0 12px 24px rgba(11, 116, 209, 0.35);
 }
 
+.quad-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(280px, 1fr));
+  gap: 24px;
+  max-width: 960px;
+  width: 100%;
+}
+
+.quad {
+  background: var(--card-bg);
+  border-radius: var(--border-radius);
+  padding: 24px;
+  box-shadow: 0 12px 34px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 20px;
+}
+
+.quad__header {
+  display: grid;
+  gap: 6px;
+}
+
+.quad__title {
+  margin: 0;
+  font-size: 22px;
+}
+
+.quad__note {
+  margin: 0;
+  color: var(--muted-color);
+  font-size: 14px;
+}
+
+.quad-form {
+  display: grid;
+  gap: 16px;
+}
+
+.checkbox-group {
+  display: grid;
+  gap: 10px;
+}
+
+.checkbox {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 14px;
+  border: 1px solid rgba(11, 116, 209, 0.18);
+  border-radius: 12px;
+  transition: border-color var(--transition), background var(--transition);
+}
+
+.checkbox input {
+  width: 18px;
+  height: 18px;
+}
+
+.checkbox:hover,
+.checkbox:focus-within {
+  border-color: var(--accent);
+  background: rgba(11, 116, 209, 0.08);
+}
+
+.happiness-output {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border: 1px solid rgba(11, 116, 209, 0.18);
+  border-radius: 12px;
+  background: rgba(11, 116, 209, 0.06);
+}
+
+.happiness-output__label {
+  font-weight: 600;
+  color: var(--muted-color);
+}
+
+.happiness-output__value {
+  width: 90px;
+  text-align: center;
+  font-size: 20px;
+  font-weight: 700;
+  border: none;
+  background: transparent;
+  color: var(--accent-dark);
+}
+
+.card-details {
+  border: 1px dashed rgba(11, 116, 209, 0.25);
+  border-radius: 14px;
+  padding: 16px;
+  min-height: 120px;
+}
+
+.details-list {
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.details-list__item {
+  display: grid;
+  gap: 4px;
+}
+
+.details-list__item dt {
+  font-weight: 600;
+  color: var(--muted-color);
+}
+
+.details-list__item dd {
+  margin: 0;
+}
+
+.placeholder {
+  margin: 0;
+  color: var(--muted-color);
+  font-size: 14px;
+}
+
+.radio-group {
+  border: 1px solid rgba(11, 116, 209, 0.18);
+  border-radius: 14px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.radio-group__legend {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 15px;
+}
+
+.radio input {
+  width: 18px;
+  height: 18px;
+}
+
+#card-error,
+#phone-error,
+#comment-error {
+  min-height: 18px;
+}
+
 @media (max-width: 768px) {
   .app {
     padding: 24px 12px 40px;
@@ -497,6 +652,10 @@ body {
 
   .pagination {
     padding-bottom: 32px;
+  }
+
+  .quad-grid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a new lifestyle.html page with four quadrants covering comment validation, happiness index, card setup, and phone mask scenarios
- extend the shared script with toast handling, card logic, happiness index calculation, and input masks used on the new page
- update pagination links and styles to support the new layout and components

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de5d7b4f90832089ab353f59e4fdb0